### PR TITLE
Replaced ▼ with a proper css notation

### DIFF
--- a/fm.selectator.jquery.css
+++ b/fm.selectator.jquery.css
@@ -42,7 +42,8 @@
 }
 .selectator:after {
 	position: absolute;
-	content: '▼';
+	cursor: pointer;
+	content: '\25BC';
 	font-size: 90%;
 	right: 4px;
 	color: #aaa;


### PR DESCRIPTION
The ▼ comes as a bunch of symbols when trying to use this .css file
